### PR TITLE
using only 9 accounts

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -8,9 +8,11 @@ export const initializeEnigma = (enigma) => {
 
 // Redux action for when web3 accounts have been initialized
 export const initializeAccounts = (accounts) => {
+    // TODO: change this back to using all accounts after issue is fixed
     return {
         type: 'ACCOUNTS_INITIALIZED',
-        payload: accounts
+        //payload: accounts
+        payload: accounts.slice(0, 9)
     };
 };
 


### PR DESCRIPTION
The 10th account does not get $ENG tokens at `discovery start` so for now the DApp will only include the 1st 9 accounts to choose from.